### PR TITLE
documentation: add `master` as a selectable version

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -27,7 +27,6 @@ jobs:
   deploy:
     name: Deploy Site
     runs-on: ubuntu-20.04
-    if: github.event.repository.fork == false
     steps:
       - uses: actions/checkout@v3
         with:

--- a/custom-theme/choose_doc_version.html
+++ b/custom-theme/choose_doc_version.html
@@ -1,8 +1,12 @@
 <select class="form-control" onchange="if (this.value) window.location.href=this.value">
   <option value="/latest">
+    Version: latest
+  </option>
+
+  <option value="/master/" {% if config.extra.version=="master" %}selected="selected" {% endif %}>
     Version: master
   </option>
-  <option value="/v1_12_0/" {% if config.extra.version=="v1_12_0" %}selected="selected" {% endif %}>
+    <option value="/v1_12_0/" {% if config.extra.version=="v1_12_0" %}selected="selected" {% endif %}>
     Version: 1.12.0
   </option>
   <option value="/v1_11_0/" {% if config.extra.version=="v1_11_0" %}selected="selected" {% endif %}>

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,9 +1,9 @@
 # Apache Mynewt Documentation
 
 -   Latest version:
-    -   [latest](/latest/)
+    -   [1.12.0](/latest/)
+    -   [master (development)](/master/)
 -   Earlier versions:
-    -   [1.12.0](/v1_12_0/)
     -   [1.11.0](/v1_11_0/)
     -   [1.10.0](/v1_10_0/)
     -   [1.9.0](/v1_9_0/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ markdown_extensions:
           pygments_style: xcode
 
 extra:
-    version: "master"
+    version: "1.12.0"
     versions:
         - label: "master"
           sha: "master"


### PR DESCRIPTION
Adds the master branch documentation as an option to choose from the drop-down list in the `Documentation` section.